### PR TITLE
2024 5a: add faster solution

### DIFF
--- a/2024/aoc_5a/aoc5a.h
+++ b/2024/aoc_5a/aoc5a.h
@@ -3,88 +3,97 @@
 
 #include <string_view>
 #include <array>
+#include <string>
+#include <map>
 #include <vector>
-#include <sstream>
+#include <set>
+#include <algorithm>
+#include <iterator>
+#include <cassert>
+
+/*
+ideas for speeding up:
+    combine reading rules and updates, i.e. it's a waste to loop twice
+    create a map for rules, i.e. faster access
+*/
 
 namespace aoc5a
 {
-    template <std::size_t N>
-    std::vector<std::pair<int, int>> readOrderRules(const std::array<std::string_view, N>& lines)
-    {
-        std::vector<std::pair<int, int>> rules {};
-        
-        for (std::string_view line : lines)
-        {
-            if (line.find('|') == std::string_view::npos)
-                continue;
-
-            size_t pipe {line.find('|')};
-            int num1 {std::stoi(std::string(line.substr(0, pipe)))};
-            int num2 {std::stoi(std::string(line.substr(pipe + 1)))};
-            rules.push_back({num1, num2});
-        }
-
-        return rules;
-    }
+    using Page = int;
+    using UniquePages = std::set<Page>;
+    using Rules = std::map<Page, UniquePages>;
+    using Updates = std::vector<Page>;
+    using UpdateLists = std::vector<Updates>;
 
     template <std::size_t N>
-    std::vector<std::vector<int>> readPageUpdates(const std::array<std::string_view, N>& lines)
+    void readRulesAndUpdates(Rules& rules, UpdateLists& updates, const std::array<std::string_view, N>& lines)
     {
-        std::vector<std::vector<int>> updates {};
-
-        for (std::string_view line : lines)
+        for (const std::string_view& line : lines)
         {
-            if (line.find(',') == std::string_view::npos)
-                continue;
-            
-            size_t start {0};
-            size_t end {0};
-            std::vector<int> innerVec {};
-
-            while (end != std::string_view::npos)
+            // collect rules if there's a '|' in the line
+            if (line.find('|') != std::string_view::npos)
             {
-                end = line.find(',', start);
-                int num {std::stoi(std::string(line.substr(start, end - start)))};
-                innerVec.push_back(num);
-                start = end + 1;
+                size_t pipe {line.find('|')};
+                int num1 {std::stoi(std::string(line.substr(0, pipe)))};
+                int num2 {std::stoi(std::string(line.substr(pipe + 1)))};
+                rules[num1].insert(num2);
             }
 
-            updates.push_back(innerVec);
-        }
-
-        return updates;
-    }
-
-    bool isUpdateValid(const std::vector<int>& update, const std::vector<std::pair<int, int>>& rules)
-    {
-        for (const std::pair<int, int>& rule : rules)
-        {
-            bool activeSearch {false};
-            for (int number : update)
+            // collect updates if there's a ',' in the line
+            else if (line.find(',') != std::string_view::npos)
             {
-                if (rule.second == number)
-                    activeSearch = true;
-                if ((activeSearch) && (rule.first == number))
-                    return false;
+                size_t index {0};
+                size_t comma {};
+                Updates inner {};
+                while (comma != std::string_view::npos)
+                {
+                    comma = line.find(',', index);
+                    int num {std::stoi(std::string(line.substr(index, comma)))};
+                    inner.push_back(num);
+                    index = comma + 1;
+                }
+                updates.push_back(inner);
             }
         }
-        return true;
     }
 
-    int getMiddleNumber(const std::vector<int>& update)
+    int getMiddleNumber(const Updates& updates)
     {
-        size_t middle {(update.size() - 1) / 2};
-        return update.at(middle);
+        assert(updates.size() % 2 != 0 && "Error: got an unexpected even number of page numbers while looking for middle page.\n");
+        size_t middleIndex {(updates.size() - 1) / 2};
+        return updates.at(middleIndex);
     }
 
-    int applyRulesToUpdates(const std::vector<std::pair<int, int>>& rules, const std::vector<std::vector<int>>& updates)
+    int findCorrectUpdatesAndGetMiddleNumber(const Rules& rules, const UpdateLists& updateLists)
     {
         int sum {0};
 
-        for (std::size_t i{0}; i < updates.size(); ++i)
+        for (const Updates& updates : updateLists)
         {
-            if (isUpdateValid(updates[i], rules))
-                sum += getMiddleNumber(updates[i]);
+            UniquePages previous {};
+            bool isCorrectOrder {true};
+            for (const Page& page : updates)
+            {
+                // check if any previous elements are in rules for current
+                // rules for current element are those that should be after
+                // if they're before then the order is incorrect
+                UniquePages intersection;
+                std::set_intersection(previous.begin(), previous.end(), 
+                                      rules.at(page).begin(), rules.at(page).end(),
+                                      std::inserter(intersection, intersection.begin()));
+                if (!intersection.empty())
+                {
+                    isCorrectOrder = false;
+                    break;
+                }
+
+                previous.insert(page);
+            }
+
+            if (isCorrectOrder)
+            {
+                sum += getMiddleNumber(updates);
+            }
         }
 
         return sum;
@@ -93,10 +102,11 @@ namespace aoc5a
     template <std::size_t N>
     int parseAndSumMiddlePages(const std::array<std::string_view, N>& lines)
     {
-        std::vector<std::pair<int, int>> orderRules {readOrderRules<N>(lines)};
-        std::vector<std::vector<int>> pageUpdates {readPageUpdates<N>(lines)};
+        Rules orderRules {};
+        UpdateLists pageUpdates {};
+        readRulesAndUpdates<N>(orderRules, pageUpdates, lines);
 
-        return {applyRulesToUpdates(orderRules, pageUpdates)};
+        return findCorrectUpdatesAndGetMiddleNumber(orderRules, pageUpdates);
     }
 }
 

--- a/2024/aoc_5a/aoc5a.h
+++ b/2024/aoc_5a/aoc5a.h
@@ -9,7 +9,7 @@
 namespace aoc5a
 {
     template <std::size_t N>
-    std::vector<std::pair<int, int>> readOrderRules(std::array<std::string_view, N> lines)
+    std::vector<std::pair<int, int>> readOrderRules(const std::array<std::string_view, N>& lines)
     {
         std::vector<std::pair<int, int>> rules {};
         
@@ -28,7 +28,7 @@ namespace aoc5a
     }
 
     template <std::size_t N>
-    std::vector<std::vector<int>> readPageUpdates(std::array<std::string_view, N> lines)
+    std::vector<std::vector<int>> readPageUpdates(const std::array<std::string_view, N>& lines)
     {
         std::vector<std::vector<int>> updates {};
 
@@ -55,7 +55,7 @@ namespace aoc5a
         return updates;
     }
 
-    bool isUpdateValid(std::vector<int> update, std::vector<std::pair<int, int>> rules)
+    bool isUpdateValid(const std::vector<int>& update, const std::vector<std::pair<int, int>>& rules)
     {
         for (const std::pair<int, int>& rule : rules)
         {
@@ -71,13 +71,13 @@ namespace aoc5a
         return true;
     }
 
-    int getMiddleNumber(std::vector<int> update)
+    int getMiddleNumber(const std::vector<int>& update)
     {
         size_t middle {(update.size() - 1) / 2};
         return update.at(middle);
     }
 
-    int applyRulesToUpdates(std::vector<std::pair<int, int>> rules, std::vector<std::vector<int>> updates)
+    int applyRulesToUpdates(const std::vector<std::pair<int, int>>& rules, const std::vector<std::vector<int>>& updates)
     {
         int sum {0};
 
@@ -91,7 +91,7 @@ namespace aoc5a
     }
 
     template <std::size_t N>
-    int parseAndSumMiddlePages(std::array<std::string_view, N> lines)
+    int parseAndSumMiddlePages(const std::array<std::string_view, N>& lines)
     {
         std::vector<std::pair<int, int>> orderRules {readOrderRules<N>(lines)};
         std::vector<std::vector<int>> pageUpdates {readPageUpdates<N>(lines)};

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Time taken (runtime) for each solution, to the nearest 0.001s if under 1 second:
 | 2     | 0.003s   | 0.007s   |
 | 3     | 0.001s   | 0.001s   |
 | 4     | 0.000s   | 0.000s   |
-| 5     | 0.020s   | 0.182s   |
+| 5     | 0.005s   | 0.182s   |
 | 6     | 0.003s   | 41.7s    |
 | 7     | 0.203s   | 15.5s    |
 | 8     | 0.004s   | 0.004s   |


### PR DESCRIPTION
This PR changes the 2024 day 5a solution.

Changes made:
- use map for ordering rules
- use set_intersection to identify when pages are in the wrong order

These changes make the solution about 4 times faster.