### PR TITLE
2016 9b: add faster solution

### DIFF
--- a/2016/README.md
+++ b/2016/README.md
@@ -13,7 +13,7 @@ Time taken (runtime) for each solution, to the nearest 0.001s if under 1 second.
 | 6     | 0.014s   | 0.014s   | Clojure     |
 | 7     | 0.282s   | 0.317s   | Clojure     |
 | 8     | 0.017s   | 0.029s   | Clojure     |
-| 9     | 0.417s   | 32.9s    | Clojure     |
+| 9     | 0.417s   | 6.0s    | Clojure     |
 | 10    |    |    |    |
 | 11    |    |    |    |
 | 12    |    |    |    |

--- a/2016/aoc_9b/src/aoc_9b/core.clj
+++ b/2016/aoc_9b/src/aoc_9b/core.clj
@@ -49,19 +49,18 @@ X(8x2)(3x3)ABCY
     (remove nil? (map #(when (true? %1) (inc %2)) bracket-positions positions))))
 
 (defn get-multipliers-for-line [start-position [span multiplier] text-length]
-  (flatten (conj (vec (repeat start-position 1))
-                 (vec (repeat span multiplier))
-                 (vec (repeat (- text-length (+ start-position span)) 1)))))
+  (into [] (concat (into [] (repeat start-position 1))
+                   (into [] (repeat span multiplier))
+                   (into [] (repeat (- text-length (+ start-position span)) 1)))))
 
 (defn is-digit? [chr]
   (and (>= (int chr) (int \0)) (<= (int chr) (int \9))))
 
 (defn clean-multiplier [text multiplier]
-  (let [brackets (map #(or (= \( %) (= \) %)) (seq text))
-        digits (map is-digit? (seq text))
-        xs (map #(= \x %) (seq text))
-        any-of-above (map #(or %1 %2 %3) brackets digits xs)]
-    (map #(if (true? %1) 0 %2) any-of-above multiplier)))
+  (map #(if (or (= \( %1)
+                (= \) %1)
+                (is-digit? %1)
+                (= \x %1)) 0 %2) text multiplier))
 
 (defn get-multipliers [text]
   (let [identity-multipliers (repeat (count text) 1)
@@ -70,12 +69,12 @@ X(8x2)(3x3)ABCY
         start-positions (get-start-positions text)
         multipliers (map #(get-multipliers-for-line %1 %2 (count text)) start-positions repeat-info)
         cleaned-multipliers (map #(clean-multiplier text %) multipliers)]
-    (apply map * cleaned-multipliers)))
+    (reduce (fn [a b] (mapv * a b)) cleaned-multipliers)))
 
 (defn decompressed-length [input]
   (let [cleaned-input (clean-and-split-input input)
         multipliers (map get-multipliers cleaned-input)]
-    (reduce #(+ %1 (reduce + %2)) 0 multipliers)))
+    (reduce + (mapcat identity multipliers))))
 
 (defn -main []
   (let [start (System/nanoTime)


### PR DESCRIPTION
**Purpose**
This PR changes the 2016 day 9b solution to code that runs faster.

This has been done to help me understand ways to make my Clojure code faster. My plan is to ignore speed for Clojure and focus on making readable code that makes use of Clojure patterns, which seem to make some Advent of Code problems easier to figure out.

**Changes made**
- replace `flatten` with `into []`, which reduced the runtime by c10s. Also replaced `conj` with `concat` and `vec` with `into []`
- replace the step-wise logic for the `clean-multiplier` function into one line combining all the logic. I think this also reduced the time by c10s
- replace `apply` with logic using `reduce`, which reduced runtime by c10s
- replace the nested `reduce` code with a single `reduce` and `mapcat`. This reduced runtime by <1s

These changes make the solution about 80% faster than before.